### PR TITLE
Potential fix for code scanning alert no. 80: Type confusion through parameter tampering

### DIFF
--- a/backend/routes/api/questions.js
+++ b/backend/routes/api/questions.js
@@ -131,6 +131,13 @@ router.post('/bulk-upload-images', AuthMiddleware.authenticateToken, upload.arra
     const userId = req.user?.id;
     const uploadResults = [];
     
+    // Ensure req.files is an array to prevent type confusion
+    if (!Array.isArray(req.files)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid files format'
+      });
+    }
     // Upload each image file
     for (let i = 0; i < req.files.length; i++) {
       const file = req.files[i];


### PR DESCRIPTION
Potential fix for [https://github.com/PandaDev0069/TUIZ/security/code-scanning/80](https://github.com/PandaDev0069/TUIZ/security/code-scanning/80)

To fix the problem, we should ensure that `req.files` is an array before iterating over it. If it is not an array (or is missing), we should return an error response. This check should be added just before the loop that processes `req.files`. The best way is to use `Array.isArray(req.files)` to verify the type. If the check fails, return a 400 Bad Request with an appropriate error message. No new imports are needed, and the change should be made in `backend/routes/api/questions.js` just before the `for (let i = 0; i < req.files.length; i++) {` loop.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
