### PR TITLE
docs: add backend file documentation

### DIFF
--- a/doc/backend/.npmrc.md
+++ b/doc/backend/.npmrc.md
@@ -1,0 +1,13 @@
+# .npmrc
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/CHECKPOINT_7_DTOs_VALIDATION_SUMMARY.md.md
+++ b/doc/backend/CHECKPOINT_7_DTOs_VALIDATION_SUMMARY.md.md
@@ -1,0 +1,13 @@
+# CHECKPOINT_7_DTOs_VALIDATION_SUMMARY.md
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/README.md.md
+++ b/doc/backend/README.md.md
@@ -1,0 +1,28 @@
+# README.md
+
+## Imports
+- express-rate-limit
+- joi
+- winston
+
+## Exports
+
+## Functions
+- handleGameEvents
+- validateCreateQuiz
+
+## Variables
+- handleGameEvents
+- gameService
+- authController
+- rateLimit
+- limiter
+- Joi
+- validateCreateQuiz
+- supabase
+- winston
+- logger
+
+## Data Flow
+- Inputs: express-rate-limit, joi, winston
+- Outputs: None

--- a/doc/backend/adapters/QuestionFormatAdapter.js.md
+++ b/doc/backend/adapters/QuestionFormatAdapter.js.md
@@ -1,0 +1,18 @@
+# adapters/QuestionFormatAdapter.js
+
+## Imports
+- ../config/gameConfig
+
+## Exports
+- QuestionFormatAdapter
+
+## Functions
+
+## Variables
+- gameConfig
+- isDevelopment
+- isLocalhost
+
+## Data Flow
+- Inputs: ../config/gameConfig
+- Outputs: QuestionFormatAdapter

--- a/doc/backend/app.js.md
+++ b/doc/backend/app.js.md
@@ -1,0 +1,53 @@
+# app.js
+
+## Imports
+- dotenv
+- express
+- cors
+- jsonwebtoken
+- ./utils/logger
+- ./config/database
+- ./utils/SupabaseAuthHelper
+- ./utils/CleanupScheduler
+- ./middleware/rateLimiter
+- ./utils/storageConfig
+- ./config/env
+- ./config/cors
+- ./routes/auth
+- ./helpers/authHelper
+- ./routes/api/questionSets
+- ./routes/api/questions
+- ./routes/api/answers
+- ./routes/api/debug
+- ./routes/api/games
+- ./routes/api/quiz
+- ./routes/upload
+- ./routes/api/playerManagement
+- ./routes/api/players
+- ./routes/api/gameResults
+- ./routes/api/gameSettings
+- ./routes/api/host/gameControl
+- ./routes/api/host/playerManagement
+- ./routes/api/host/gameCreation
+
+## Exports
+- { createApp }
+
+## Functions
+- createApp
+- doesn
+- not
+
+## Variables
+- express
+- cors
+- jwt
+- logger
+- DatabaseManager
+- SupabaseAuthHelper
+- CleanupScheduler
+- RateLimitMiddleware
+
+## Data Flow
+- Inputs: dotenv, express, cors, jsonwebtoken, ./utils/logger, ./config/database, ./utils/SupabaseAuthHelper, ./utils/CleanupScheduler, ./middleware/rateLimiter, ./utils/storageConfig, ./config/env, ./config/cors, ./routes/auth, ./helpers/authHelper, ./routes/api/questionSets, ./routes/api/questions, ./routes/api/answers, ./routes/api/debug, ./routes/api/games, ./routes/api/quiz, ./routes/upload, ./routes/api/playerManagement, ./routes/api/players, ./routes/api/gameResults, ./routes/api/gameSettings, ./routes/api/host/gameControl, ./routes/api/host/playerManagement, ./routes/api/host/gameCreation
+- Outputs: { createApp }

--- a/doc/backend/config/cleanupConfig.js.md
+++ b/doc/backend/config/cleanupConfig.js.md
@@ -1,0 +1,16 @@
+# config/cleanupConfig.js
+
+## Imports
+
+## Exports
+- cleanupConfig
+
+## Functions
+- to
+
+## Variables
+- cleanupConfig
+
+## Data Flow
+- Inputs: None
+- Outputs: cleanupConfig

--- a/doc/backend/config/cors.js.md
+++ b/doc/backend/config/cors.js.md
@@ -1,0 +1,28 @@
+# config/cors.js
+
+## Imports
+
+## Exports
+- {
+  getAllowedOrigins,
+  getSocketAllowedOrigins,
+  getExpressCorsConfig,
+  getSocketCorsConfig
+}
+
+## Functions
+- getAllowedOrigins
+- getSocketAllowedOrigins
+- getExpressCorsConfig
+- getSocketCorsConfig
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  getAllowedOrigins,
+  getSocketAllowedOrigins,
+  getExpressCorsConfig,
+  getSocketCorsConfig
+}

--- a/doc/backend/config/database.js.md
+++ b/doc/backend/config/database.js.md
@@ -1,0 +1,27 @@
+# config/database.js
+
+## Imports
+- dotenv
+- @supabase/supabase-js
+- crypto
+- ../utils/logger
+- ./cleanupConfig
+
+## Exports
+- DatabaseManager
+
+## Functions
+- const
+- not
+- to
+
+## Variables
+- crypto
+- logger
+- supabaseUrl
+- supabaseKey
+- supabaseServiceKey
+
+## Data Flow
+- Inputs: dotenv, @supabase/supabase-js, crypto, ../utils/logger, ./cleanupConfig
+- Outputs: DatabaseManager

--- a/doc/backend/config/env.js.md
+++ b/doc/backend/config/env.js.md
@@ -1,0 +1,26 @@
+# config/env.js
+
+## Imports
+- dotenv
+
+## Exports
+- {
+  getEnvironment,
+  getServerConfig,
+  getSupabaseConfig
+}
+
+## Functions
+- getEnvironment
+- getServerConfig
+- getSupabaseConfig
+
+## Variables
+
+## Data Flow
+- Inputs: dotenv
+- Outputs: {
+  getEnvironment,
+  getServerConfig,
+  getSupabaseConfig
+}

--- a/doc/backend/config/gameConfig.js.md
+++ b/doc/backend/config/gameConfig.js.md
@@ -1,0 +1,15 @@
+# config/gameConfig.js
+
+## Imports
+
+## Exports
+- gameConfig
+
+## Functions
+
+## Variables
+- gameConfig
+
+## Data Flow
+- Inputs: None
+- Outputs: gameConfig

--- a/doc/backend/config/questionTypeMapping.js.md
+++ b/doc/backend/config/questionTypeMapping.js.md
@@ -1,0 +1,22 @@
+# config/questionTypeMapping.js
+
+## Imports
+
+## Exports
+- {
+  QUESTION_TYPES,
+  QuestionTypeUtils
+}
+
+## Functions
+
+## Variables
+- QUESTION_TYPES
+- QuestionTypeUtils
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  QUESTION_TYPES,
+  QuestionTypeUtils
+}

--- a/doc/backend/data/questions.json.md
+++ b/doc/backend/data/questions.json.md
@@ -1,0 +1,13 @@
+# data/questions.json
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/debug_rls_fix.js.md
+++ b/doc/backend/debug_rls_fix.js.md
@@ -1,0 +1,19 @@
+# debug_rls_fix.js
+
+## Imports
+- @supabase/supabase-js
+- dotenv
+
+## Exports
+
+## Functions
+- debugRLSIssue
+
+## Variables
+- supabaseUrl
+- supabaseServiceKey
+- supabaseAdmin
+
+## Data Flow
+- Inputs: @supabase/supabase-js, dotenv
+- Outputs: None

--- a/doc/backend/domain/game/actions.js.md
+++ b/doc/backend/domain/game/actions.js.md
@@ -1,0 +1,37 @@
+# domain/game/actions.js
+
+## Imports
+- ./questionFlow
+- ./explanation
+- ./lifecycle
+- ./statistics
+- ../../config/env
+
+## Exports
+- {
+  sendNextQuestion,
+  proceedToNextQuestion,
+  showQuestionExplanation,
+  showIntermediateLeaderboard
+}
+
+## Functions
+- sendNextQuestion
+- proceedToNextQuestion
+- sendPlayerAnswerData
+- handleExplanationAutoAdvance
+- for
+- showQuestionExplanation
+- handleLeaderboardAutoAdvance
+- showIntermediateLeaderboard
+
+## Variables
+
+## Data Flow
+- Inputs: ./questionFlow, ./explanation, ./lifecycle, ./statistics, ../../config/env
+- Outputs: {
+  sendNextQuestion,
+  proceedToNextQuestion,
+  showQuestionExplanation,
+  showIntermediateLeaderboard
+}

--- a/doc/backend/domain/game/endGame.js.md
+++ b/doc/backend/domain/game/endGame.js.md
@@ -1,0 +1,27 @@
+# domain/game/endGame.js
+
+## Imports
+- ./lifecycle
+- ../../config/env
+- ../../services/GameService
+
+## Exports
+- {
+  endGame
+}
+
+## Functions
+- canEndGame
+- updateGameStatusInDatabase
+- handleQuestionSetIncrement
+- updateQuestionSetLastPlayed
+- emitGameCompletionEvents
+- endGame
+
+## Variables
+
+## Data Flow
+- Inputs: ./lifecycle, ../../config/env, ../../services/GameService
+- Outputs: {
+  endGame
+}

--- a/doc/backend/domain/game/explanation.js.md
+++ b/doc/backend/domain/game/explanation.js.md
@@ -1,0 +1,32 @@
+# domain/game/explanation.js
+
+## Imports
+- ./statistics
+
+## Exports
+- {
+  prepareExplanationData,
+  prepareLeaderboardData,
+  getCorrectAnswerText,
+  prepareExplanationState,
+  shouldShowExplanation
+}
+
+## Functions
+- prepareExplanationData
+- prepareLeaderboardData
+- getCorrectAnswerText
+- prepareExplanationState
+- shouldShowExplanation
+
+## Variables
+
+## Data Flow
+- Inputs: ./statistics
+- Outputs: {
+  prepareExplanationData,
+  prepareLeaderboardData,
+  getCorrectAnswerText,
+  prepareExplanationState,
+  shouldShowExplanation
+}

--- a/doc/backend/domain/game/index.js.md
+++ b/doc/backend/domain/game/index.js.md
@@ -1,0 +1,36 @@
+# domain/game/index.js
+
+## Imports
+- ./statistics
+- ./questionFlow
+- ./explanation
+- ./lifecycle
+- ./actions
+- ./endGame
+
+## Exports
+- {
+  // Re-export key modules for convenience
+  statistics: require('./statistics'),
+  questionFlow: require('./questionFlow'),
+  explanation: require('./explanation'),
+  lifecycle: require('./lifecycle'),
+  actions: require('./actions'),
+  endGame: require('./endGame')
+}
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: ./statistics, ./questionFlow, ./explanation, ./lifecycle, ./actions, ./endGame
+- Outputs: {
+  // Re-export key modules for convenience
+  statistics: require('./statistics'),
+  questionFlow: require('./questionFlow'),
+  explanation: require('./explanation'),
+  lifecycle: require('./lifecycle'),
+  actions: require('./actions'),
+  endGame: require('./endGame')
+}

--- a/doc/backend/domain/game/lifecycle.js.md
+++ b/doc/backend/domain/game/lifecycle.js.md
@@ -1,0 +1,41 @@
+# domain/game/lifecycle.js
+
+## Imports
+- ./statistics
+
+## Exports
+- {
+  prepareGameOverData,
+  prepareGameEndState,
+  calculatePlayerStats,
+  prepareGameResultData,
+  getEligiblePlayersForDb,
+  shouldEndGame,
+  preparePlayerRankings,
+  cleanupGameTimers
+}
+
+## Functions
+- prepareGameOverData
+- prepareGameEndState
+- calculatePlayerStats
+- prepareGameResultData
+- getEligiblePlayersForDb
+- shouldEndGame
+- preparePlayerRankings
+- cleanupGameTimers
+
+## Variables
+
+## Data Flow
+- Inputs: ./statistics
+- Outputs: {
+  prepareGameOverData,
+  prepareGameEndState,
+  calculatePlayerStats,
+  prepareGameResultData,
+  getEligiblePlayersForDb,
+  shouldEndGame,
+  preparePlayerRankings,
+  cleanupGameTimers
+}

--- a/doc/backend/domain/game/questionFlow.js.md
+++ b/doc/backend/domain/game/questionFlow.js.md
@@ -1,0 +1,31 @@
+# domain/game/questionFlow.js
+
+## Imports
+
+## Exports
+- {
+  prepareQuestionData,
+  prepareQuestionState,
+  initializePlayerStreaks,
+  shouldProceedToNext,
+  prepareQuestionTransition
+}
+
+## Functions
+- prepareQuestionData
+- prepareQuestionState
+- initializePlayerStreaks
+- shouldProceedToNext
+- prepareQuestionTransition
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  prepareQuestionData,
+  prepareQuestionState,
+  initializePlayerStreaks,
+  shouldProceedToNext,
+  prepareQuestionTransition
+}

--- a/doc/backend/domain/game/statistics.js.md
+++ b/doc/backend/domain/game/statistics.js.md
@@ -1,0 +1,25 @@
+# domain/game/statistics.js
+
+## Imports
+
+## Exports
+- {
+  calculateAnswerStatistics,
+  calculateLeaderboard,
+  getCurrentPlayerAnswerData
+}
+
+## Functions
+- calculateAnswerStatistics
+- calculateLeaderboard
+- getCurrentPlayerAnswerData
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  calculateAnswerStatistics,
+  calculateLeaderboard,
+  getCurrentPlayerAnswerData
+}

--- a/doc/backend/dtos/index.js.md
+++ b/doc/backend/dtos/index.js.md
@@ -1,0 +1,54 @@
+# dtos/index.js
+
+## Imports
+
+## Exports
+- {
+  // Core Game DTOs
+  GameStateDTO: null,
+  PlayerDTO: null,
+  QuestionDTO: null,
+  AnswerSubmissionDTO: null,
+  GameJoinDTO: null,
+  HostActionDTO: null,
+  GameResultsDTO: null,
+  
+  // Response DTOs
+  ErrorDTO: null,
+  SuccessDTO: null,
+  
+  // Socket Event DTOs
+  SocketEventDTO: null,
+  PlayerJoinedEventDTO: null,
+  QuestionStartEventDTO: null,
+  AnswerRevealEventDTO: null,
+  LeaderboardEventDTO: null
+}
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  // Core Game DTOs
+  GameStateDTO: null,
+  PlayerDTO: null,
+  QuestionDTO: null,
+  AnswerSubmissionDTO: null,
+  GameJoinDTO: null,
+  HostActionDTO: null,
+  GameResultsDTO: null,
+  
+  // Response DTOs
+  ErrorDTO: null,
+  SuccessDTO: null,
+  
+  // Socket Event DTOs
+  SocketEventDTO: null,
+  PlayerJoinedEventDTO: null,
+  QuestionStartEventDTO: null,
+  AnswerRevealEventDTO: null,
+  LeaderboardEventDTO: null
+}

--- a/doc/backend/helpers/authHelper.js.md
+++ b/doc/backend/helpers/authHelper.js.md
@@ -1,0 +1,28 @@
+# helpers/authHelper.js
+
+## Imports
+- ../config/database
+- ../utils/logger
+
+## Exports
+- {
+  getAuthenticatedUser
+}
+
+## Functions
+- to
+- getAuthenticatedUser
+
+## Variables
+- DatabaseManager
+- logger
+- db
+- isDevelopment
+- isLocalhost
+- getAuthenticatedUser
+
+## Data Flow
+- Inputs: ../config/database, ../utils/logger
+- Outputs: {
+  getAuthenticatedUser
+}

--- a/doc/backend/middleware/auth.js.md
+++ b/doc/backend/middleware/auth.js.md
@@ -1,0 +1,28 @@
+# middleware/auth.js
+
+## Imports
+- jsonwebtoken
+- @supabase/supabase-js
+- ../utils/logger
+
+## Exports
+- AuthMiddleware
+
+## Functions
+- const
+
+## Variables
+- jwt
+- logger
+- isDevelopment
+- isLocalhost
+- supabaseUrl
+- supabaseServiceKey
+- supabaseJwtSecret
+- supabaseAdmin
+- tokenCache
+- CACHE_DURATION
+
+## Data Flow
+- Inputs: jsonwebtoken, @supabase/supabase-js, ../utils/logger
+- Outputs: AuthMiddleware

--- a/doc/backend/middleware/hostAuth.js.md
+++ b/doc/backend/middleware/hostAuth.js.md
@@ -1,0 +1,45 @@
+# middleware/hostAuth.js
+
+## Imports
+- jsonwebtoken
+- ../utils/RoomManager
+- ../utils/logger
+
+## Exports
+- {
+  validateHostPermission,
+  validateGameState,
+  validateMinimumPlayers,
+  hostActionRateLimit,
+  validateHostActionPermissions,
+  logHostAction
+}
+
+## Functions
+- validateHostPermission
+- validateGameState
+- validateMinimumPlayers
+- hostActionRateLimit
+- validateHostActionPermissions
+- logHostAction
+
+## Variables
+- jwt
+- logger
+- validateHostPermission
+- validateGameState
+- validateMinimumPlayers
+- hostActionRateLimit
+- validateHostActionPermissions
+- logHostAction
+
+## Data Flow
+- Inputs: jsonwebtoken, ../utils/RoomManager, ../utils/logger
+- Outputs: {
+  validateHostPermission,
+  validateGameState,
+  validateMinimumPlayers,
+  hostActionRateLimit,
+  validateHostActionPermissions,
+  logHostAction
+}

--- a/doc/backend/middleware/rateLimiter.js.md
+++ b/doc/backend/middleware/rateLimiter.js.md
@@ -1,0 +1,17 @@
+# middleware/rateLimiter.js
+
+## Imports
+- express-rate-limit
+
+## Exports
+- RateLimitMiddleware
+
+## Functions
+
+## Variables
+- rateLimit
+- isDevelopment
+
+## Data Flow
+- Inputs: express-rate-limit
+- Outputs: RateLimitMiddleware

--- a/doc/backend/package.json.md
+++ b/doc/backend/package.json.md
@@ -1,0 +1,13 @@
+# package.json
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/render.yaml.md
+++ b/doc/backend/render.yaml.md
@@ -1,0 +1,13 @@
+# render.yaml
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/routes/api/answers.js.md
+++ b/doc/backend/routes/api/answers.js.md
@@ -1,0 +1,32 @@
+# routes/api/answers.js
+
+## Imports
+- express
+- multer
+- ../../config/database
+- ../../middleware/auth
+- ../../helpers/authHelper
+- ../../utils/OrderManager
+- ../../utils/logger
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- multer
+- DatabaseManager
+- AuthMiddleware
+- db
+- OrderManager
+- logger
+- orderManager
+- storage
+- upload
+
+## Data Flow
+- Inputs: express, multer, ../../config/database, ../../middleware/auth, ../../helpers/authHelper, ../../utils/OrderManager, ../../utils/logger
+- Outputs: router

--- a/doc/backend/routes/api/debug.js.md
+++ b/doc/backend/routes/api/debug.js.md
@@ -1,0 +1,21 @@
+# routes/api/debug.js
+
+## Imports
+- express
+- ../../config/database
+- ../../helpers/authHelper
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- DatabaseManager
+- db
+
+## Data Flow
+- Inputs: express, ../../config/database, ../../helpers/authHelper
+- Outputs: router

--- a/doc/backend/routes/api/gameResults.js.md
+++ b/doc/backend/routes/api/gameResults.js.md
@@ -1,0 +1,28 @@
+# routes/api/gameResults.js
+
+## Imports
+- express
+- ../../config/database
+- @supabase/supabase-js
+- ../../middleware/auth
+- ../../middleware/rateLimiter
+- ../../utils/logger
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- DatabaseManager
+- AuthMiddleware
+- RateLimitMiddleware
+- logger
+- auth
+- db
+
+## Data Flow
+- Inputs: express, ../../config/database, @supabase/supabase-js, ../../middleware/auth, ../../middleware/rateLimiter, ../../utils/logger
+- Outputs: router

--- a/doc/backend/routes/api/gameSettings.js.md
+++ b/doc/backend/routes/api/gameSettings.js.md
@@ -1,0 +1,32 @@
+# routes/api/gameSettings.js
+
+## Imports
+- express
+- ../../config/database
+- ../../middleware/auth
+- ../../utils/SecurityUtils
+- ../../utils/RoomManager
+- ../../utils/ActiveGameUpdater
+- ../../utils/logger
+
+## Exports
+- router
+
+## Functions
+- updateActiveGameSettings
+
+## Variables
+- express
+- router
+- DatabaseManager
+- AuthMiddleware
+- SecurityUtils
+- roomManager
+- activeGameUpdater
+- logger
+- db
+- DEFAULT_SETTINGS
+
+## Data Flow
+- Inputs: express, ../../config/database, ../../middleware/auth, ../../utils/SecurityUtils, ../../utils/RoomManager, ../../utils/ActiveGameUpdater, ../../utils/logger
+- Outputs: router

--- a/doc/backend/routes/api/games.js.md
+++ b/doc/backend/routes/api/games.js.md
@@ -1,0 +1,28 @@
+# routes/api/games.js
+
+## Imports
+- express
+- ../../utils/RoomManager
+- ../../helpers/authHelper
+- ../../config/database
+- ../../middleware/rateLimiter
+- ../../utils/logger
+- ../../validation
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- roomManager
+- DatabaseManager
+- RateLimitMiddleware
+- logger
+- db
+
+## Data Flow
+- Inputs: express, ../../utils/RoomManager, ../../helpers/authHelper, ../../config/database, ../../middleware/rateLimiter, ../../utils/logger, ../../validation
+- Outputs: router

--- a/doc/backend/routes/api/host/gameControl.js.md
+++ b/doc/backend/routes/api/host/gameControl.js.md
@@ -1,0 +1,23 @@
+# routes/api/host/gameControl.js
+
+## Imports
+- express
+- ../../../middleware/hostAuth
+- ../../../utils/RoomManager
+- ../../../utils/logger
+- ../../../server
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- RoomManager
+- logger
+
+## Data Flow
+- Inputs: express, ../../../middleware/hostAuth, ../../../utils/RoomManager, ../../../utils/logger, ../../../server
+- Outputs: router

--- a/doc/backend/routes/api/host/gameCreation.js.md
+++ b/doc/backend/routes/api/host/gameCreation.js.md
@@ -1,0 +1,24 @@
+# routes/api/host/gameCreation.js
+
+## Imports
+- express
+- @supabase/supabase-js
+- ../../../middleware/hostAuth
+- ../../../utils/logger
+
+## Exports
+- router
+
+## Functions
+- to
+- generateGameCode
+
+## Variables
+- express
+- router
+- logger
+- supabase
+
+## Data Flow
+- Inputs: express, @supabase/supabase-js, ../../../middleware/hostAuth, ../../../utils/logger
+- Outputs: router

--- a/doc/backend/routes/api/host/playerManagement.js.md
+++ b/doc/backend/routes/api/host/playerManagement.js.md
@@ -1,0 +1,23 @@
+# routes/api/host/playerManagement.js
+
+## Imports
+- express
+- ../../../middleware/hostAuth
+- ../../../utils/RoomManager
+- ../../../utils/logger
+- ../../../server
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- RoomManager
+- logger
+
+## Data Flow
+- Inputs: express, ../../../middleware/hostAuth, ../../../utils/RoomManager, ../../../utils/logger, ../../../server
+- Outputs: router

--- a/doc/backend/routes/api/playerManagement.js.md
+++ b/doc/backend/routes/api/playerManagement.js.md
@@ -1,0 +1,27 @@
+# routes/api/playerManagement.js
+
+## Imports
+- express
+- ../../utils/logger
+
+## Exports
+- (dbManager) => {
+  // Test endpoint for player UUID management
+  router.post('/test-player-uuid', async (req, res) => {
+    try {
+      const { userId, playerName } = req.body
+
+## Functions
+
+## Variables
+- express
+- logger
+- router
+
+## Data Flow
+- Inputs: express, ../../utils/logger
+- Outputs: (dbManager) => {
+  // Test endpoint for player UUID management
+  router.post('/test-player-uuid', async (req, res) => {
+    try {
+      const { userId, playerName } = req.body

--- a/doc/backend/routes/api/players.js.md
+++ b/doc/backend/routes/api/players.js.md
@@ -1,0 +1,27 @@
+# routes/api/players.js
+
+## Imports
+- express
+- ../../utils/logger
+
+## Exports
+- (dbManager) => {
+  // Get all players in a game
+  router.get('/game/:gameId', async (req, res) => {
+    try {
+      const { gameId } = req.params
+
+## Functions
+
+## Variables
+- express
+- logger
+- router
+
+## Data Flow
+- Inputs: express, ../../utils/logger
+- Outputs: (dbManager) => {
+  // Get all players in a game
+  router.get('/game/:gameId', async (req, res) => {
+    try {
+      const { gameId } = req.params

--- a/doc/backend/routes/api/questionSets.js.md
+++ b/doc/backend/routes/api/questionSets.js.md
@@ -1,0 +1,32 @@
+# routes/api/questionSets.js
+
+## Imports
+- express
+- multer
+- path
+- ../../config/database
+- ../../middleware/auth
+- ../../utils/SecurityUtils
+- ../../utils/logger
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- router
+- multer
+- path
+- DatabaseManager
+- AuthMiddleware
+- SecurityUtils
+- logger
+- db
+- storage
+- upload
+
+## Data Flow
+- Inputs: express, multer, path, ../../config/database, ../../middleware/auth, ../../utils/SecurityUtils, ../../utils/logger
+- Outputs: router

--- a/doc/backend/routes/api/questions.js.md
+++ b/doc/backend/routes/api/questions.js.md
@@ -1,0 +1,42 @@
+# routes/api/questions.js
+
+## Imports
+- express
+- ../../utils/logger
+- multer
+- express-rate-limit
+- ../../config/database
+- ../../middleware/auth
+- ../../middleware/rateLimiter
+- ../../utils/SecurityUtils
+- ../../validation
+- ../../utils/OrderManager
+
+## Exports
+- router
+
+## Functions
+- to
+- isValidUUID
+- isBlobUrl
+
+## Variables
+- express
+- logger
+- router
+- multer
+- rateLimit
+- DatabaseManager
+- AuthMiddleware
+- RateLimitMiddleware
+- SecurityUtils
+- db
+- OrderManager
+- orderManager
+- deleteImageLimiter
+- storage
+- upload
+
+## Data Flow
+- Inputs: express, ../../utils/logger, multer, express-rate-limit, ../../config/database, ../../middleware/auth, ../../middleware/rateLimiter, ../../utils/SecurityUtils, ../../validation, ../../utils/OrderManager
+- Outputs: router

--- a/doc/backend/routes/api/quiz.js.md
+++ b/doc/backend/routes/api/quiz.js.md
@@ -1,0 +1,41 @@
+# routes/api/quiz.js
+
+## Imports
+- express
+- multer
+- path
+- fs
+- ../../config/database
+- ../../middleware/auth
+- ../../utils/SecurityUtils
+- ../../middleware/rateLimiter
+- ../../utils/logger
+- ../../utils/ActiveGameUpdater
+
+## Exports
+- router
+
+## Functions
+- fileFilter
+- copyImageToNewLocation
+
+## Variables
+- express
+- multer
+- path
+- fs
+- DatabaseManager
+- AuthMiddleware
+- SecurityUtils
+- RateLimitMiddleware
+- logger
+- dbManager
+- supabase
+- router
+- storage
+- fileFilter
+- upload
+
+## Data Flow
+- Inputs: express, multer, path, fs, ../../config/database, ../../middleware/auth, ../../utils/SecurityUtils, ../../middleware/rateLimiter, ../../utils/logger, ../../utils/ActiveGameUpdater
+- Outputs: router

--- a/doc/backend/routes/api/results.js.md
+++ b/doc/backend/routes/api/results.js.md
@@ -1,0 +1,27 @@
+# routes/api/results.js
+
+## Imports
+- express
+- ../../utils/logger
+
+## Exports
+- (dbManager) => {
+  // Get game results for a specific game
+  router.get('/game/:gameId', async (req, res) => {
+    try {
+      const { gameId } = req.params
+
+## Functions
+
+## Variables
+- express
+- logger
+- router
+
+## Data Flow
+- Inputs: express, ../../utils/logger
+- Outputs: (dbManager) => {
+  // Get game results for a specific game
+  router.get('/game/:gameId', async (req, res) => {
+    try {
+      const { gameId } = req.params

--- a/doc/backend/routes/auth.js.md
+++ b/doc/backend/routes/auth.js.md
@@ -1,0 +1,36 @@
+# routes/auth.js
+
+## Imports
+- express
+- @supabase/supabase-js
+- multer
+- path
+- ../middleware/auth
+- ../middleware/rateLimiter
+- ../utils/logger
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- multer
+- path
+- AuthMiddleware
+- RateLimitMiddleware
+- logger
+- router
+- supabaseUrl
+- supabaseAnonKey
+- supabaseServiceKey
+- supabase
+- supabaseAdmin
+- storage
+- upload
+- validateInput
+
+## Data Flow
+- Inputs: express, @supabase/supabase-js, multer, path, ../middleware/auth, ../middleware/rateLimiter, ../utils/logger
+- Outputs: router

--- a/doc/backend/routes/upload.js.md
+++ b/doc/backend/routes/upload.js.md
@@ -1,0 +1,30 @@
+# routes/upload.js
+
+## Imports
+- express
+- multer
+- path
+- ../middleware/auth
+- ../config/database
+- ../utils/logger
+
+## Exports
+- router
+
+## Functions
+
+## Variables
+- express
+- multer
+- path
+- AuthMiddleware
+- DatabaseManager
+- logger
+- router
+- db
+- storage
+- upload
+
+## Data Flow
+- Inputs: express, multer, path, ../middleware/auth, ../config/database, ../utils/logger
+- Outputs: router

--- a/doc/backend/scripts/apply_analytics_snapshot_migration.js.md
+++ b/doc/backend/scripts/apply_analytics_snapshot_migration.js.md
@@ -1,0 +1,13 @@
+# scripts/apply_analytics_snapshot_migration.js
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/scripts/apply_host_control_migration.js.md
+++ b/doc/backend/scripts/apply_host_control_migration.js.md
@@ -1,0 +1,23 @@
+# scripts/apply_host_control_migration.js
+
+## Imports
+- @supabase/supabase-js
+- fs
+- path
+- dotenv
+
+## Exports
+
+## Functions
+- applyHostControlMigration
+
+## Variables
+- fs
+- path
+- supabaseUrl
+- supabaseServiceKey
+- supabase
+
+## Data Flow
+- Inputs: @supabase/supabase-js, fs, path, dotenv
+- Outputs: None

--- a/doc/backend/scripts/apply_migration.js.md
+++ b/doc/backend/scripts/apply_migration.js.md
@@ -1,0 +1,23 @@
+# scripts/apply_migration.js
+
+## Imports
+- @supabase/supabase-js
+- fs
+- path
+- dotenv
+
+## Exports
+
+## Functions
+- applyMigration
+
+## Variables
+- fs
+- path
+- supabaseUrl
+- supabaseServiceKey
+- supabase
+
+## Data Flow
+- Inputs: @supabase/supabase-js, fs, path, dotenv
+- Outputs: None

--- a/doc/backend/scripts/apply_player_action_migration.js.md
+++ b/doc/backend/scripts/apply_player_action_migration.js.md
@@ -1,0 +1,18 @@
+# scripts/apply_player_action_migration.js
+
+## Imports
+- @supabase/supabase-js
+- dotenv
+
+## Exports
+
+## Functions
+- updatePlayerActionTypes
+
+## Variables
+- supabaseUrl
+- supabaseServiceKey
+
+## Data Flow
+- Inputs: @supabase/supabase-js, dotenv
+- Outputs: None

--- a/doc/backend/scripts/check_schema.js.md
+++ b/doc/backend/scripts/check_schema.js.md
@@ -1,0 +1,19 @@
+# scripts/check_schema.js
+
+## Imports
+- @supabase/supabase-js
+- dotenv
+
+## Exports
+
+## Functions
+- checkSchema
+
+## Variables
+- supabaseUrl
+- supabaseAnonKey
+- supabase
+
+## Data Flow
+- Inputs: @supabase/supabase-js, dotenv
+- Outputs: None

--- a/doc/backend/scripts/create_player_answers_table.js.md
+++ b/doc/backend/scripts/create_player_answers_table.js.md
@@ -1,0 +1,22 @@
+# scripts/create_player_answers_table.js
+
+## Imports
+- @supabase/supabase-js
+- fs
+- path
+
+## Exports
+
+## Functions
+- createPlayerAnswersTable
+
+## Variables
+- fs
+- path
+- supabaseUrl
+- supabaseServiceKey
+- supabase
+
+## Data Flow
+- Inputs: @supabase/supabase-js, fs, path
+- Outputs: None

--- a/doc/backend/scripts/create_player_answers_table.sql.md
+++ b/doc/backend/scripts/create_player_answers_table.sql.md
@@ -1,0 +1,13 @@
+# scripts/create_player_answers_table.sql
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/scripts/disable_trigger.sql.md
+++ b/doc/backend/scripts/disable_trigger.sql.md
@@ -1,0 +1,14 @@
+# scripts/disable_trigger.sql
+
+## Imports
+
+## Exports
+
+## Functions
+- but
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/scripts/fix_game_results_constraint.sql.md
+++ b/doc/backend/scripts/fix_game_results_constraint.sql.md
@@ -1,0 +1,13 @@
+# scripts/fix_game_results_constraint.sql
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/scripts/fix_game_results_relationship.js.md
+++ b/doc/backend/scripts/fix_game_results_relationship.js.md
@@ -1,0 +1,19 @@
+# scripts/fix_game_results_relationship.js
+
+## Imports
+- path
+- dotenv
+- @supabase/supabase-js
+
+## Exports
+- { runMigration }
+
+## Functions
+- runMigration
+
+## Variables
+- path
+
+## Data Flow
+- Inputs: path, dotenv, @supabase/supabase-js
+- Outputs: { runMigration }

--- a/doc/backend/scripts/fix_trigger_foreign_key.js.md
+++ b/doc/backend/scripts/fix_trigger_foreign_key.js.md
@@ -1,0 +1,22 @@
+# scripts/fix_trigger_foreign_key.js
+
+## Imports
+- @supabase/supabase-js
+- fs
+- path
+
+## Exports
+
+## Functions
+- fixTriggerForeignKey
+
+## Variables
+- fs
+- path
+- supabaseUrl
+- supabaseServiceKey
+- supabase
+
+## Data Flow
+- Inputs: @supabase/supabase-js, fs, path
+- Outputs: None

--- a/doc/backend/scripts/fix_trigger_foreign_key.sql.md
+++ b/doc/backend/scripts/fix_trigger_foreign_key.sql.md
@@ -1,0 +1,13 @@
+# scripts/fix_trigger_foreign_key.sql
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/scripts/migrate.js.md
+++ b/doc/backend/scripts/migrate.js.md
@@ -1,0 +1,19 @@
+# scripts/migrate.js
+
+## Imports
+- path
+- dotenv
+- @supabase/supabase-js
+
+## Exports
+- runMigration
+
+## Functions
+- runMigration
+
+## Variables
+- path
+
+## Data Flow
+- Inputs: path, dotenv, @supabase/supabase-js
+- Outputs: runMigration

--- a/doc/backend/scripts/test_game_results.js.md
+++ b/doc/backend/scripts/test_game_results.js.md
@@ -1,0 +1,19 @@
+# scripts/test_game_results.js
+
+## Imports
+- ../config/database
+
+## Exports
+
+## Functions
+- testGameResults
+- console
+- working
+- failed
+
+## Variables
+- DatabaseManager
+
+## Data Flow
+- Inputs: ../config/database
+- Outputs: None

--- a/doc/backend/scripts/update-logging.js.md
+++ b/doc/backend/scripts/update-logging.js.md
@@ -1,0 +1,26 @@
+# scripts/update-logging.js
+
+## Imports
+- fs
+- path
+- ../utils/logger
+- ./utils/logger
+- ${relativePath}
+
+## Exports
+- { updateConsoleStatements }
+
+## Functions
+- updateConsoleStatements
+- main
+
+## Variables
+- fs
+- path
+- filesToUpdate
+- updateConsoleStatements
+- main
+
+## Data Flow
+- Inputs: fs, path, ../utils/logger, ./utils/logger, ${relativePath}
+- Outputs: { updateConsoleStatements }

--- a/doc/backend/scripts/update_timing_precision.sql.md
+++ b/doc/backend/scripts/update_timing_precision.sql.md
@@ -1,0 +1,13 @@
+# scripts/update_timing_precision.sql
+
+## Imports
+
+## Exports
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: None

--- a/doc/backend/server.js.md
+++ b/doc/backend/server.js.md
@@ -1,0 +1,92 @@
+# server.js
+
+## Imports
+- dotenv
+- ./utils/logger
+- http
+- ./config/database
+- ./utils/CleanupScheduler
+- ./utils/RoomManager
+- ./services/QuestionService
+- ./services/GameService
+- ./services/ResultsService
+- ./services/PlayerService
+- ./services/HostOpsService
+- ./adapters/QuestionFormatAdapter
+- ./services/GameSettingsService
+- ./utils/scoringSystem
+- ./utils/storageConfig
+- ./utils/ActiveGameUpdater
+- ./app
+- ./sockets
+- ./config/env
+- ./config/cors
+- ./validation
+- ./utils/responseHelpers
+- ./domain/game/actions
+- ./domain/game/endGame
+- ./domain/game/statistics
+- ./sockets/hostHandlers
+- ./domain/game/explanation
+
+## Exports
+- getIO
+- getGameHub
+
+## Functions
+- to
+- setupHostHandlers
+- registerMainSocketHandlers
+- exists
+- checkForQuestionCompletion
+- showQuestionExplanation
+- showIntermediateLeaderboard
+- proceedToNextQuestion
+- sendNextQuestion
+- updatePlayerRankings
+- createGameResultsForPlayers
+- endGame
+
+## Variables
+- logger
+- http
+- DatabaseManager
+- CleanupScheduler
+- roomManager
+- QuestionService
+- GameService
+- ResultsService
+- PlayerService
+- HostOpsService
+- QuestionFormatAdapter
+- GameSettingsService
+- activeGameUpdater
+- gameActions
+- gameEndModule
+- HostSocketHandlers
+- db
+- questionService
+- gameService
+- resultsService
+- playerService
+- hostOpsService
+- questionAdapter
+- cleanupScheduler
+- app
+- activeGames
+- server
+- hostHandlers
+- checkForQuestionCompletion
+- showQuestionExplanation
+- showIntermediateLeaderboard
+- getCorrectAnswerText
+- getCurrentPlayerAnswerData
+- proceedToNextQuestion
+- sendNextQuestion
+- updatePlayerRankings
+- createGameResultsForPlayers
+- endGame
+
+## Data Flow
+- Inputs: dotenv, ./utils/logger, http, ./config/database, ./utils/CleanupScheduler, ./utils/RoomManager, ./services/QuestionService, ./services/GameService, ./services/ResultsService, ./services/PlayerService, ./services/HostOpsService, ./adapters/QuestionFormatAdapter, ./services/GameSettingsService, ./utils/scoringSystem, ./utils/storageConfig, ./utils/ActiveGameUpdater, ./app, ./sockets, ./config/env, ./config/cors, ./validation, ./utils/responseHelpers, ./domain/game/actions, ./domain/game/endGame, ./domain/game/statistics, ./sockets/hostHandlers, ./domain/game/explanation
+- Outputs: getIO, getGameHub

--- a/doc/backend/services/GameService.js.md
+++ b/doc/backend/services/GameService.js.md
@@ -1,0 +1,16 @@
+# services/GameService.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- GameService
+
+## Functions
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: GameService

--- a/doc/backend/services/GameSettingsService.js.md
+++ b/doc/backend/services/GameSettingsService.js.md
@@ -1,0 +1,19 @@
+# services/GameSettingsService.js
+
+## Imports
+- ../config/gameConfig.js
+- ../utils/logger
+
+## Exports
+- GameSettingsService
+
+## Functions
+
+## Variables
+- gameConfig
+- logger
+- isDevelopment
+
+## Data Flow
+- Inputs: ../config/gameConfig.js, ../utils/logger
+- Outputs: GameSettingsService

--- a/doc/backend/services/HostOpsService.js.md
+++ b/doc/backend/services/HostOpsService.js.md
@@ -1,0 +1,17 @@
+# services/HostOpsService.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- HostOpsService
+
+## Functions
+- for
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: HostOpsService

--- a/doc/backend/services/PlayerService.js.md
+++ b/doc/backend/services/PlayerService.js.md
@@ -1,0 +1,16 @@
+# services/PlayerService.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- PlayerService
+
+## Functions
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: PlayerService

--- a/doc/backend/services/QuestionService.js.md
+++ b/doc/backend/services/QuestionService.js.md
@@ -1,0 +1,16 @@
+# services/QuestionService.js
+
+## Imports
+- ../config/database
+
+## Exports
+- QuestionService
+
+## Functions
+
+## Variables
+- DatabaseManager
+
+## Data Flow
+- Inputs: ../config/database
+- Outputs: QuestionService

--- a/doc/backend/services/ResultsService.js.md
+++ b/doc/backend/services/ResultsService.js.md
@@ -1,0 +1,16 @@
+# services/ResultsService.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- ResultsService
+
+## Functions
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: ResultsService

--- a/doc/backend/sockets/GameHub.js.md
+++ b/doc/backend/sockets/GameHub.js.md
@@ -1,0 +1,16 @@
+# sockets/GameHub.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- GameHub
+
+## Functions
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: GameHub

--- a/doc/backend/sockets/events/sessionRestore.js.md
+++ b/doc/backend/sockets/events/sessionRestore.js.md
@@ -1,0 +1,19 @@
+# sockets/events/sessionRestore.js
+
+## Imports
+- ../../utils/logger
+- ../sessionRestoreHandlers
+
+## Exports
+- { register }
+
+## Functions
+- register
+
+## Variables
+- logger
+- SessionRestoreHandlers
+
+## Data Flow
+- Inputs: ../../utils/logger, ../sessionRestoreHandlers
+- Outputs: { register }

--- a/doc/backend/sockets/hostHandlers.js.md
+++ b/doc/backend/sockets/hostHandlers.js.md
@@ -1,0 +1,25 @@
+# sockets/hostHandlers.js
+
+## Imports
+- ../utils/RoomManager
+- ../utils/logger
+- ../adapters/QuestionFormatAdapter
+- ../services/QuestionService
+- ../services/GameSettingsService
+- ../validation
+
+## Exports
+- HostSocketHandlers
+
+## Functions
+
+## Variables
+- RoomManager
+- logger
+- QuestionFormatAdapter
+- QuestionService
+- GameSettingsService
+
+## Data Flow
+- Inputs: ../utils/RoomManager, ../utils/logger, ../adapters/QuestionFormatAdapter, ../services/QuestionService, ../services/GameSettingsService, ../validation
+- Outputs: HostSocketHandlers

--- a/doc/backend/sockets/index.js.md
+++ b/doc/backend/sockets/index.js.md
@@ -1,0 +1,24 @@
+# sockets/index.js
+
+## Imports
+- socket.io
+- ../utils/logger
+- ../config/env
+- ../config/cors
+- ./events/sessionRestore
+- ./GameHub
+
+## Exports
+- { initializeSocketIO }
+
+## Functions
+- initializeSocketIO
+
+## Variables
+- logger
+- sessionRestoreEvents
+- GameHub
+
+## Data Flow
+- Inputs: socket.io, ../utils/logger, ../config/env, ../config/cors, ./events/sessionRestore, ./GameHub
+- Outputs: { initializeSocketIO }

--- a/doc/backend/sockets/sessionRestoreHandlers.js.md
+++ b/doc/backend/sockets/sessionRestoreHandlers.js.md
@@ -1,0 +1,18 @@
+# sockets/sessionRestoreHandlers.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- SessionRestoreHandlers
+
+## Functions
+
+## Variables
+- logger
+- isDevelopment
+- isLocalhost
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: SessionRestoreHandlers

--- a/doc/backend/test/testPlayerManagement.js.md
+++ b/doc/backend/test/testPlayerManagement.js.md
@@ -1,0 +1,20 @@
+# test/testPlayerManagement.js
+
+## Imports
+- path
+- dotenv
+- ../config/database
+
+## Exports
+- testPlayerManagement
+
+## Functions
+- testPlayerManagement
+
+## Variables
+- path
+- DatabaseManager
+
+## Data Flow
+- Inputs: path, dotenv, ../config/database
+- Outputs: testPlayerManagement

--- a/doc/backend/utils/ActiveGameUpdater.js.md
+++ b/doc/backend/utils/ActiveGameUpdater.js.md
@@ -1,0 +1,16 @@
+# utils/ActiveGameUpdater.js
+
+## Imports
+- ./logger
+
+## Exports
+- new ActiveGameUpdater()
+
+## Functions
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ./logger
+- Outputs: new ActiveGameUpdater()

--- a/doc/backend/utils/CleanupScheduler.js.md
+++ b/doc/backend/utils/CleanupScheduler.js.md
@@ -1,0 +1,17 @@
+# utils/CleanupScheduler.js
+
+## Imports
+- ../config/cleanupConfig
+- ../server
+
+## Exports
+- CleanupScheduler
+
+## Functions
+
+## Variables
+- cleanupConfig
+
+## Data Flow
+- Inputs: ../config/cleanupConfig, ../server
+- Outputs: CleanupScheduler

--- a/doc/backend/utils/OrderManager.js.md
+++ b/doc/backend/utils/OrderManager.js.md
@@ -1,0 +1,18 @@
+# utils/OrderManager.js
+
+## Imports
+- ../config/database
+- ./logger
+
+## Exports
+- OrderManager
+
+## Functions
+
+## Variables
+- DatabaseManager
+- logger
+
+## Data Flow
+- Inputs: ../config/database, ./logger
+- Outputs: OrderManager

--- a/doc/backend/utils/RoomManager.js.md
+++ b/doc/backend/utils/RoomManager.js.md
@@ -1,0 +1,18 @@
+# utils/RoomManager.js
+
+## Imports
+- ../config/gameConfig
+- ./SecurityUtils
+
+## Exports
+- new RoomManager()
+
+## Functions
+
+## Variables
+- gameConfig
+- SecurityUtils
+
+## Data Flow
+- Inputs: ../config/gameConfig, ./SecurityUtils
+- Outputs: new RoomManager()

--- a/doc/backend/utils/SecurityUtils.js.md
+++ b/doc/backend/utils/SecurityUtils.js.md
@@ -1,0 +1,21 @@
+# utils/SecurityUtils.js
+
+## Imports
+- path
+- crypto
+- ./logger
+
+## Exports
+- SecurityUtils
+
+## Functions
+- calls
+
+## Variables
+- path
+- crypto
+- logger
+
+## Data Flow
+- Inputs: path, crypto, ./logger
+- Outputs: SecurityUtils

--- a/doc/backend/utils/SupabaseAuthHelper.js.md
+++ b/doc/backend/utils/SupabaseAuthHelper.js.md
@@ -1,0 +1,18 @@
+# utils/SupabaseAuthHelper.js
+
+## Imports
+- jsonwebtoken
+- ./logger
+
+## Exports
+- SupabaseAuthHelper
+
+## Functions
+
+## Variables
+- jwt
+- logger
+
+## Data Flow
+- Inputs: jsonwebtoken, ./logger
+- Outputs: SupabaseAuthHelper

--- a/doc/backend/utils/logger.js.md
+++ b/doc/backend/utils/logger.js.md
@@ -1,0 +1,14 @@
+# utils/logger.js
+
+## Imports
+
+## Exports
+- new Logger()
+
+## Functions
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: new Logger()

--- a/doc/backend/utils/responseHelpers.js.md
+++ b/doc/backend/utils/responseHelpers.js.md
@@ -1,0 +1,54 @@
+# utils/responseHelpers.js
+
+## Imports
+- ../utils/logger
+
+## Exports
+- {
+  sendSuccess,
+  sendError,
+  sendValidationError,
+  sendNotFound,
+  sendUnauthorized,
+  sendForbidden,
+  sendRateLimit,
+  createSocketResponse,
+  formatGameState,
+  formatQuestion,
+  formatPlayer,
+  formatLeaderboard
+}
+
+## Functions
+- sendSuccess
+- sendError
+- sendValidationError
+- sendNotFound
+- sendUnauthorized
+- sendForbidden
+- sendRateLimit
+- createSocketResponse
+- formatGameState
+- formatQuestion
+- formatPlayer
+- formatLeaderboard
+
+## Variables
+- logger
+
+## Data Flow
+- Inputs: ../utils/logger
+- Outputs: {
+  sendSuccess,
+  sendError,
+  sendValidationError,
+  sendNotFound,
+  sendUnauthorized,
+  sendForbidden,
+  sendRateLimit,
+  createSocketResponse,
+  formatGameState,
+  formatQuestion,
+  formatPlayer,
+  formatLeaderboard
+}

--- a/doc/backend/utils/scoringSystem.js.md
+++ b/doc/backend/utils/scoringSystem.js.md
@@ -1,0 +1,26 @@
+# utils/scoringSystem.js
+
+## Imports
+
+## Exports
+- {
+  calculateScore,
+  getScoreBreakdown,
+  calculateGameScore
+}
+
+## Functions
+- calculateScore
+- getScoreBreakdown
+- that
+- calculateGameScore
+
+## Variables
+
+## Data Flow
+- Inputs: None
+- Outputs: {
+  calculateScore,
+  getScoreBreakdown,
+  calculateGameScore
+}

--- a/doc/backend/utils/storageConfig.js.md
+++ b/doc/backend/utils/storageConfig.js.md
@@ -1,0 +1,34 @@
+# utils/storageConfig.js
+
+## Imports
+- ./logger
+
+## Exports
+- {
+  validateStorageConfig,
+  getStorageBucketInfo,
+  generateStoragePath,
+  getStorageBucket
+}
+
+## Functions
+- validateStorageConfig
+- getStorageBucketInfo
+- generateStoragePath
+- getStorageBucket
+
+## Variables
+- logger
+- validateStorageConfig
+- getStorageBucketInfo
+- generateStoragePath
+- getStorageBucket
+
+## Data Flow
+- Inputs: ./logger
+- Outputs: {
+  validateStorageConfig,
+  getStorageBucketInfo,
+  generateStoragePath,
+  getStorageBucket
+}

--- a/doc/backend/validation/index.js.md
+++ b/doc/backend/validation/index.js.md
@@ -1,0 +1,35 @@
+# validation/index.js
+
+## Imports
+- ../utils/logger.js
+
+## Exports
+- {
+  ValidationError,
+  validators,
+  gameValidators,
+  schemas,
+  createValidator,
+  validateSocketPayload
+}
+
+## Functions
+- createValidator
+- validateSocketPayload
+
+## Variables
+- logger
+- validators
+- gameValidators
+- schemas
+
+## Data Flow
+- Inputs: ../utils/logger.js
+- Outputs: {
+  ValidationError,
+  validators,
+  gameValidators,
+  schemas,
+  createValidator,
+  validateSocketPayload
+}


### PR DESCRIPTION
## Summary
- add autogenerated documentation for each backend file
- include imports, exports, functions, variables, and data flow summary

## Testing
- `npm test` *(fails: supabaseKey is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c2e023e8832597e0c4f8b340af06